### PR TITLE
This commit provides a hotfix for a critical bug that was causing the…

### DIFF
--- a/app/search/services.py
+++ b/app/search/services.py
@@ -36,7 +36,6 @@ def google_search_service(
         # We pass advanced=True to get SearchResult objects instead of just URLs.
         results_generator = google_search_lib(
             q,
-            tld='com', # Make search more consistent
             num_results=num_results,
             lang=language,
             start_num=start,


### PR DESCRIPTION
… entire search API to fail.

The `search()` function from the `googlesearch-python` library was being called with an unsupported keyword argument, `tld`. This was added in a previous commit in an attempt to improve search reliability but instead caused a `TypeError`, making the endpoint return a 500 error.

This commit removes the invalid `tld='com'` parameter from the function call in `app/search/services.py`.

This change restores the search functionality.