### PR TITLE
This commit provides a hotfix for a critical bug that caused the `/ne…

### DIFF
--- a/app/news/services.py
+++ b/app/news/services.py
@@ -82,7 +82,7 @@ def get_news_service(
         entries = search_result.get('entries', [])
 
         # Paginate the results
-        paginated_entries = search_result.entries[start : start + num_results]
+        paginated_entries = entries[start : start + num_results]
 
         article_list = []
         for entry in paginated_entries:


### PR DESCRIPTION
…ws/` endpoint to crash with an `AttributeError: 'dict' object has no attribute 'entries'`.

The error was caused by incorrect logic in `app/news/services.py` when trying to paginate the results. The code was attempting to access `.entries` on the `search_result` dictionary after the list of entries had already been extracted.

The fix corrects this logic by performing the list slicing on the `entries` variable itself, which correctly holds the list of articles.

This resolves the backend crash and restores the news functionality.