### PR TITLE
This commit delivers two final polishing features to the chat history…

### DIFF
--- a/other-project/index.html
+++ b/other-project/index.html
@@ -217,8 +217,14 @@
                 chatMessages.scrollTop = chatMessages.scrollHeight;
 
                 if (sender !== 'system') {
-                    const messageForHistory = isRawHtml ? `[Stellar displayed a visual element]` : message;
-                    chatHistory.push({ sender, message: messageForHistory, id: messageId });
+                    // Save the raw message and the flag to render it as HTML correctly
+                    chatHistory.push({ sender, message, isRawHtml, id: messageId });
+
+                    // Enforce the 20-message limit
+                    if (chatHistory.length > 20) {
+                        chatHistory.shift(); // Remove the oldest message
+                    }
+
                     saveChatHistory();
                 }
                 return messageId;
@@ -646,7 +652,8 @@
                 if (savedHistory) {
                     chatHistory = JSON.parse(savedHistory);
                     chatMessages.innerHTML = '';
-                    chatHistory.forEach(item => addMessage(item.sender, item.message, true));
+                    // Use the saved isRawHtml flag to correctly re-render messages
+                    chatHistory.forEach(item => addMessage(item.sender, item.message, item.isRawHtml));
                 }
             };
 


### PR DESCRIPTION
… functionality based on user feedback.

1.  **Fix Rich Content in History:** The application now correctly saves and reloads messages containing rich HTML content (like stock and news cards). The `localStorage` object now stores the raw HTML and an `isRawHtml` flag, which is used by the `loadChatHistory` function to re-render the visual elements perfectly on page reload. This fixes the bug where rich content was replaced by the placeholder `[Stellar displayed a visual element]`.

2.  **Implement Rolling History Limit:** The chat history is now capped at a maximum of 20 messages. When a new message is added that exceeds this limit, the oldest message in the history is automatically removed. This keeps the chat history clean and manages memory usage.