### PR TITLE
fix(news): Ensure date filters work without a search query

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,6 @@ GET /search/
 - `description` - Meta description or snippet
 - `source` - Domain source
 - `rank` - Search result position
-- `date` - Last modified date (when available)
 
 ### Language Codes
 | Code | Language | Code | Language | Code | Language |
@@ -294,7 +293,6 @@ curl "https://swipeapis.vercel.app/news/?region=DE&language=de&category=business
       "url": "https://example.com/ai-healthcare",
       "source": "Tech News Daily",
       "published_at": "2025-08-24T14:30:00Z",
-      "author": "Dr. Sarah Johnson",
       "category": "technology",
       "region": "US",
       "language": "en",


### PR DESCRIPTION
Previously, the News API would ignore `from_date` and `to_date` parameters if a search query `q` was not provided. This was because the code would call the `top_news()` method instead of the `search()` method.

This commit fixes the logic in `app/news/services.py` to ensure that if a date filter is present, the `search()` method is always used. If no search query `q` is provided by the user, a default query ("top stories") is used to allow for date-based filtering of general news.