### PR TITLE
feat: add rate limiting to public APIs

### DIFF
--- a/app/finance/router.py
+++ b/app/finance/router.py
@@ -1,13 +1,16 @@
-from fastapi import APIRouter, HTTPException, Query, Path
+from fastapi import APIRouter, HTTPException, Query, Path, Request
 from typing import Optional
 from .services import get_finance_data_service, TickerNotFoundError, \
     YFinanceError
+from app.limiter import limiter
 
 router = APIRouter()
 
 
 @router.get("/{ticker}", response_model=dict)
+@limiter.limit("60/minute")
 async def get_finance_data(
+    request: Request,
     ticker: str = Path(..., description="The stock ticker symbol (e.g., AAPL, GOOGL)."),
     fields: Optional[str] = Query(
         None,

--- a/app/limiter.py
+++ b/app/limiter.py
@@ -1,0 +1,5 @@
+from slowapi import Limiter
+from slowapi.util import get_remote_address
+
+# Create a global rate limiter using the client's IP address
+limiter = Limiter(key_func=get_remote_address)

--- a/app/main.py
+++ b/app/main.py
@@ -1,11 +1,14 @@
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
 from fastapi.responses import HTMLResponse
 from fastapi.middleware.cors import CORSMiddleware
+from slowapi import _rate_limit_exceeded_handler
+from slowapi.errors import RateLimitExceeded
 import markdown2
 
 from app.finance.router import router as finance_router
 from app.search.router import router as search_router
 from app.news.router import router as news_router
+from app.limiter import limiter
 
 # Disable default docs
 app = FastAPI(
@@ -15,6 +18,10 @@ app = FastAPI(
     docs_url=None,
     redoc_url=None
 )
+
+# Configure rate limiter
+app.state.limiter = limiter
+app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
 
 # Add CORS middleware to allow cross-origin requests
 app.add_middleware(
@@ -32,7 +39,8 @@ app.include_router(news_router, prefix="/news", tags=["News"])
 
 
 @app.get("/", response_class=HTMLResponse, tags=["Root"])
-async def read_root_and_serve_docs():
+@limiter.limit("100/minute")
+async def read_root_and_serve_docs(request: Request):
     
     with open("README.md", "r") as f:
         md_content = f.read()

--- a/app/news/router.py
+++ b/app/news/router.py
@@ -1,13 +1,16 @@
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, HTTPException, Query, Request
 from typing import List, Dict, Any, Optional
 from .services import get_news_service, InvalidDateFormatError, \
     NewsFetchingError
+from app.limiter import limiter
 
 router = APIRouter()
 
 
 @router.get("/", response_model=Dict[str, Any])
+@limiter.limit("60/minute")
 async def get_news(
+    request: Request,
     q: Optional[str] = Query(
         None,
         description="A search query for news articles. "

--- a/app/search/router.py
+++ b/app/search/router.py
@@ -1,13 +1,16 @@
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, HTTPException, Query, Request
 from typing import List, Dict, Any, Optional
 from .services import search_service, SearchError, EmptyQueryError, \
     ALL_FIELDS
+from app.limiter import limiter
 
 router = APIRouter()
 
 
 @router.get("/", response_model=Dict[str, Any])
+@limiter.limit("60/minute")
 async def perform_search(
+    request: Request,
     q: str = Query(..., description="The search query string."),
     num_results: int = Query(
         10, ge=1, le=100, description="The maximum number of results to return."

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ ddgs
 pygooglenews
 vaderSentiment
 markdown2
+slowapi


### PR DESCRIPTION
This change addresses the security concern of missing rate limiting for the public API endpoints. Using the `slowapi` library, an IP-based rate limiting mechanism was added across the FastAPI application.

The following changes were made:
- Added `slowapi` to `requirements.txt`.
- Created a central limiter configuration in `app/limiter.py`.
- Integrated the limiter to the FastAPI app state and added the exception handler in `app/main.py`.
- Applied a limit of `100/minute` to the root route, and `60/minute` to the `finance`, `search`, and `news` API routers.

The API remains fully public without requiring authentication or API keys, as requested.

---
*PR created automatically by Jules for task [9324741080711448036](https://jules.google.com/task/9324741080711448036) started by @iambhvsh*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented rate limiting across API endpoints to ensure fair usage and prevent abuse. Finance, news, and search endpoints are limited to 60 requests per minute, while the root endpoint allows 100 requests per minute.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->